### PR TITLE
Regex Fixes, Lenient Argument, Undefined Country

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,12 @@
-exports.validate = function (code, country) {
+/**
+* Validates a postal code for a country
+*
+* @param code      The postal code
+* @param country   The country code acronym, can be left undefined to match any country
+* @param lenient   Validates to true for any alphanumerical postal code if country code is not listed
+* @returns {boolean} returns true if the postalcode is valid, false otherwise
+*/
+exports.validate = function (code, country, lenient) {
   var regexes = {
     "UK": /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-z][A-z]){1}$/i,
     "JE": /^JE\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}$/,
@@ -44,7 +52,7 @@ exports.validate = function (code, country) {
     "KH": /^\d{5}$/,
     "CV": /^\d{4}$/,
     "CL": /^\d{7}$/,
-    "CR": /^\d{4,5}|\d{3}-\d{4}$/,
+    "CR": /^\d{4,5}$|^\d{3}-\d{4}$/,
     "HR": /^\d{5}$/,
     "CY": /^\d{4}$/,
     "CZ": /^\d{3}[ ]?\d{2}$/,
@@ -71,7 +79,7 @@ exports.validate = function (code, country) {
     "LA": /^\d{5}$/,
     "LV": /^\d{4}$/,
     "LB": /^(\d{4}([ ]?\d{4})?)?$/,
-    "LI": /^(948[5-9])|(949[0-7])$/,
+    "LI": /^(948[5-9])$|^(949[0-7])$/,
     "LT": /^\d{5}$/,
     "LU": /^\d{4}$/,
     "MK": /^\d{4}$/,
@@ -157,17 +165,22 @@ exports.validate = function (code, country) {
     "TC": /^TKCA 1ZZ$/,
     "WF": /^986\d{2}$/,
     "XK": /^\d{5}$/,
-    "YT": /^976\d{2}$/,
-    "INTL": /^(?:[A-Z0-9]+([- ]?[A-Z0-9]+)*)?$/i
+    "YT": /^976\d{2}$/
   };
 
-  country = country.toUpperCase();
+  if (country) {
+    country = country.toUpperCase();
+  }
 
   if (country in regexes) {
     return regexes[country].test(code)
   }
   for (reKey in regexes) {
     if (regexes[reKey].test(code)) { return true }
+  }
+  if((country === 'INT') || lenient){
+    let intRegEx = /^(?:[A-Z0-9]+([- ]?[A-Z0-9]+)*)?$/i
+    return intRegEx.test(code)
   }
   return false;
 };

--- a/test/all.js
+++ b/test/all.js
@@ -49,6 +49,48 @@ var postcode = require('../lib/index.js');
   assert.ok(postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid");
 });
 
+// Valid postcodes without country
+[
+  {
+    code: "10014"
+  },
+  {
+    code: "W6 8DL"
+  },
+  {
+    code: "M5P 2N7"
+  },
+  {
+    code: "100-0005"
+  },
+  {
+    code: "100020"
+  },
+  {
+    code: "SW1A 0AA"
+  }
+].forEach(function (item) {
+  assert.ok(postcode.validate(item.code), "Valid postcode " + item.code + " was invalid");
+});
+
+// Valid postcodes without country and lenient on
+[
+  {
+  code: "KFPXWT7D",
+  lenient: true
+  },
+  {
+    code: "91180-560",
+    lenient: true
+  },
+  {
+    code: "135",
+    lenient: true
+  }
+].forEach(function (item) {
+  assert.ok(postcode.validate(item.code, null, item.lenient), "Valid postcode " + item.code + " was invalid");
+});
+
 // Invalid postcodes
 [
   {
@@ -68,5 +110,23 @@ var postcode = require('../lib/index.js');
     country: "JP"
   }
 ].forEach(function (item) {
-  assert.ok(!postcode.validate(item.code, item.country), "Invalid postcode " + item.code + " for country " + item.country + " was invalid");
+  assert.ok(!postcode.validate(item.code, item.country), "Invalid postcode " + item.code + " for country " + item.country + " was valid");
+});
+
+// Invalid postcodes without country code
+[
+  {
+    code: "!,$^ +@#"
+  },
+  {
+    code: "1234567asdfafsadf4567"
+  },
+  {
+    code: "M5P@2N7"
+  },
+  {
+    code: "100-0005-9088"
+  }
+].forEach(function (item) {
+  assert.ok(!postcode.validate(item.code), "Invalid postcode " + item.code + " was valid");
 });


### PR DESCRIPTION
Fixed regex with or clauses, that did not have the closing $ or beginning ^ characters causing partial validation
Added additional `lenient` argument to allow validation on the alphanumeric INT code.
Allow undefined country to be passed in to validate against any of the listed country codes.
Update tests