### PR TITLE
validate against an array of country codes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,10 +161,12 @@ exports.validate = function (code, country) {
     "INTL": /^(?:[A-Z0-9]+([- ]?[A-Z0-9]+)*)?$/i
   };
 
-  country = country.toUpperCase();
+  if(Array.isArray(country)) {
+    return country.some((country) => regexes[country.toUpperCase()].test(code));
+  }
 
   if (country in regexes) {
-    return regexes[country].test(code)
+    return regexes[country.toUpperCase()].test(code)
   }
   for (reKey in regexes) {
     if (regexes[reKey].test(code)) { return true }

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,9 @@ exports.validate = function (code, country) {
   };
 
   if(Array.isArray(country)) {
-    return country.some((country) => regexes[country.toUpperCase()].test(code));
+    return country.some(function (country) {
+      return regexes[country.toUpperCase()].test(code);
+    });
   }
 
   if (country in regexes) {

--- a/test/all.js
+++ b/test/all.js
@@ -27,7 +27,7 @@ var postcode = require('../lib/index.js');
   },
   {
     code: "100020",
-    country: "INT"
+    country: "INTL"
   },
   {
     code: "KFPXWT7D",
@@ -92,7 +92,7 @@ var postcode = require('../lib/index.js');
   },
   {
     code: "100020",
-    country: ["INT", "JP", "UK"]
+    country: ["INTL", "JP", "UK"]
   }
 ].forEach(function (item) {
   assert.ok(postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid");
@@ -102,7 +102,7 @@ var postcode = require('../lib/index.js');
 [
   {
     code: "!,$^ +@#",
-    country: ["INT", "UK"]
+    country: ["INTL", "UK"]
   },
   {
     code: "1234567",

--- a/test/all.js
+++ b/test/all.js
@@ -94,7 +94,9 @@ var postcode = require('../lib/index.js');
     code: "100020",
     country: ["INT", "JP", "UK"]
   }
-].forEach(item => assert.ok(postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid"));
+].forEach(function (item) {
+  assert.ok(postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid");
+});
 
 // Invalid postcode groups
 [
@@ -114,4 +116,6 @@ var postcode = require('../lib/index.js');
     code: "100-0005-9088",
     country: ["JP", "US"]
   }
-].forEach(item => assert.ok(!postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid"));
+].forEach(function (item) {
+  assert.ok(!postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid");
+});

--- a/test/all.js
+++ b/test/all.js
@@ -70,3 +70,48 @@ var postcode = require('../lib/index.js');
 ].forEach(function (item) {
   assert.ok(!postcode.validate(item.code, item.country), "Invalid postcode " + item.code + " for country " + item.country + " was invalid");
 });
+
+// Postcode groups
+// Tests if it matches at least one of the country codes
+[
+  {
+    code: "10014",
+    country: ["US", "CA"]
+  },
+  {
+    code: "W6 8DL",
+    country: ["UK", "US"]
+  },
+  {
+    code: "M5P 2N7",
+    country: ["CA", "US", "UK"]
+  },
+  {
+    code: "100-0005",
+    country: ["JP", "CA", "US"]
+  },
+  {
+    code: "100020",
+    country: ["INT", "JP", "UK"]
+  }
+].forEach(item => assert.ok(postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid"));
+
+// Invalid postcode groups
+[
+  {
+    code: "!,$^ +@#",
+    country: ["INT", "UK"]
+  },
+  {
+    code: "1234567",
+    country: ["UK", "CA"]
+  },
+  {
+    code: "M5P@2N7",
+    country: ["CA", "US"]
+  },
+  {
+    code: "100-0005-9088",
+    country: ["JP", "US"]
+  }
+].forEach(item => assert.ok(!postcode.validate(item.code, item.country), "Valid postcode " + item.code + " for country " + item.country + " was invalid"));


### PR DESCRIPTION
Allows user to validate a postcode against an array of country codes and will return true if at least one country is matched.

e.g `postcode.validate('90210', ['US', 'CA'])` will `return true`