### PR TITLE
Tighten Canadian postal code validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ exports.validate = function (code, country) {
     "GG": /^GY\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}$/,
     "IM": /^IM\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}$/,
     "US": /^([0-9]{5})(?:[-\s]*([0-9]{4}))?$/,
-    "CA": /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/i,
+    "CA": /^([ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ])\s*([0-9][ABCEGHJKLMNPRSTVWXYZ][0-9])$/i,
     "DE": /^\d{5}$/,
     "JP": /^\d{3}-\d{4}$/,
     "FR": /^\d{2}[ ]?\d{3}$/,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "postcode-validator",
   "version": "1.2.0",
   "description": "Validate postcodes based on country",
-  "license": "MIT"  
   "repository": {
     "type": "git",
     "url": "git@github.com:melwynfurtado/postcode-validator"

--- a/test/all.js
+++ b/test/all.js
@@ -64,6 +64,10 @@ var postcode = require('../lib/index.js');
     country: "CA"
   },
   {
+    code: "M5K3D8",
+    country: "CA"
+  },
+  {
     code: "100-0005-9088",
     country: "JP"
   }


### PR DESCRIPTION
👋🏻 Heya! Thanks for putting this lib together! I spotted a small gap in
the validation that’s definitely worth addressing.

Postal codes like “M5K3D8” look valid, but they aren’t due to some
specific restrictions on the character set, and upstream postal code
validators will trip up on them!
[postal-codes-js](https://github.com/Cimpress-MCP/postal-codes-js/blob/master/formats/CA.json#L4)
has a very similar looking regular expression, for example.

See
https://stackoverflow.com/questions/1146202/canadian-postal-code-validation
for details

P.S. Also removes a stray line from `package.json`.