### PR TITLE
Fixes #43 : Validate postal code for ANY country

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # Dependency directories
 node_modules/
 lib/
+
+.vscode/

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
-import { CountryCodeStrings } from './postcode-types';
 import { POSTCODE_REGEXES } from './postcode-regexes';
 
-export const postcodeValidator = (postcode: string, country: CountryCodeStrings): boolean => {
+export const postcodeValidator = (postcode: string, country: string): boolean => {
 
   if (!POSTCODE_REGEXES.has(country)) {
     // throw Error if country code is unrecognised
@@ -11,6 +10,6 @@ export const postcodeValidator = (postcode: string, country: CountryCodeStrings)
   return POSTCODE_REGEXES.get(country)!.test(postcode);
 };
 
-export const postcodeValidatorExistsForCountry = (country: CountryCodeStrings): boolean => {
+export const postcodeValidatorExistsForCountry = (country: string): boolean => {
   return POSTCODE_REGEXES.has(country);
 };

--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -1,7 +1,7 @@
-import { CountryCode, CountryCodeStrings } from './postcode-types';
+import { CountryCode } from './postcode-types';
 
   // TODO: Remove CountryCode.UK in next major version release
-export const POSTCODE_REGEXES: Map<CountryCodeStrings, RegExp> = new Map([
+export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.UK, /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-z][A-z]){1}$/i],
   [CountryCode.GB, /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-z][A-z]){1}$/i],
   [CountryCode.JE, /^JE\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}$/],

--- a/src/postcode-types.ts
+++ b/src/postcode-types.ts
@@ -161,5 +161,3 @@ export enum CountryCode {
   YT = 'YT',
   INTL = 'INTL',
 }
-
-export type CountryCodeStrings = keyof typeof CountryCode;

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -2,62 +2,62 @@ import { CountryCodeStrings } from '../src/postcode-types';
 import { postcodeValidator, postcodeValidatorExistsForCountry } from '../src/main';
 
 describe('postcodeValidator', () => {
-    test('should return true for valid postcodes', () => {
-        const validPostcodes = [
-            { postcode: "10014", country: "US" },
-            { postcode: "W6 8DL", country: "GB" },
-            { postcode: "M5P 2N7", country: "CA" },
-            { postcode: "100-0005", country: "JP" },
-            { postcode: "100020", country: "INTL" },
-            { postcode: "KFPXWT7D", country: "INTL" },
-            { postcode: "91180-560", country: "INTL" },
-            { postcode: "135", country: "INTL" },
-            { postcode: "SW1A 0AA", country: "GB" },
-            { postcode: "1010", country: "AT" },
-            { postcode: "D02 TN83", country: "IE" }
-        ];
+  test('should return true for valid postcodes', () => {
+    const validPostcodes = [
+      { postcode: '10014', country: 'US' },
+      { postcode: 'W6 8DL', country: 'GB' },
+      { postcode: 'M5P 2N7', country: 'CA' },
+      { postcode: '100-0005', country: 'JP' },
+      { postcode: '100020', country: 'INTL' },
+      { postcode: 'KFPXWT7D', country: 'INTL' },
+      { postcode: '91180-560', country: 'INTL' },
+      { postcode: '135', country: 'INTL' },
+      { postcode: 'SW1A 0AA', country: 'GB' },
+      { postcode: '1010', country: 'AT' },
+      { postcode: 'D02 TN83', country: 'IE' },
+    ];
 
-        expect.assertions(validPostcodes.length);
-        validPostcodes.forEach(({ postcode, country }) => {
-            expect(postcodeValidator(postcode, country as CountryCodeStrings)).toBeTruthy();
-        });
+    expect.assertions(validPostcodes.length);
+    validPostcodes.forEach(({ postcode, country }) => {
+      expect(postcodeValidator(postcode, country as CountryCodeStrings)).toBeTruthy();
     });
+  });
 
-    test('should return false for invalid postcodes', () => {
-        const invalidPostcodes = [
-            { postcode: "!,$^ +@#", country: "INTL" },
-            { postcode: "1234567", country: "GB" },
-            { postcode: "M5P@2N7", country: "CA" },
-            { postcode: "M5K3D8", country: "CA" },
-            { postcode: "100-0005-9088", country: "JP" },
-            { postcode: "0234", country: "AT" },
-            { postcode: "DTN83", country: "IE" }
-        ];
+  test('should return false for invalid postcodes', () => {
+    const invalidPostcodes = [
+      { postcode: '!,$^ +@#', country: 'INTL' },
+      { postcode: '1234567', country: 'GB' },
+      { postcode: 'M5P@2N7', country: 'CA' },
+      { postcode: 'M5K3D8', country: 'CA' },
+      { postcode: '100-0005-9088', country: 'JP' },
+      { postcode: '0234', country: 'AT' },
+      { postcode: 'DTN83', country: 'IE' },
+    ];
 
-        expect.assertions(invalidPostcodes.length);
-        invalidPostcodes.forEach(({ postcode, country }) => {
-            expect(postcodeValidator(postcode, country as CountryCodeStrings)).toBeFalsy();
-        });
+    expect.assertions(invalidPostcodes.length);
+    invalidPostcodes.forEach(({ postcode, country }) => {
+      expect(postcodeValidator(postcode, country as CountryCodeStrings)).toBeFalsy();
     });
+  });
 
-    test('should throw error for invalid country codes', () => {
-        expect.assertions(1);
-        expect(() => postcodeValidator('SW1A 0AA', 'MOON' as CountryCodeStrings)).toThrow('Invalid country code: MOON');
-    });
+  test('should throw error for invalid country codes', () => {
+    expect.assertions(1);
+    expect(() => postcodeValidator('SW1A 0AA', 'MOON' as CountryCodeStrings)).toThrow('Invalid country code: MOON');
+  });
 });
 
 describe('postcodeValidatorExistsForCountry', () => {
-    test('should return true for valid country code', () => {
-        expect.assertions(3);
-        expect(postcodeValidatorExistsForCountry('PR')).toBeTruthy();
-        expect(postcodeValidatorExistsForCountry('AU')).toBeTruthy();
-        expect(postcodeValidatorExistsForCountry('DE')).toBeTruthy();
-    });
+  test('should return true for valid country code', () => {
+    expect.assertions(3);
+    expect(postcodeValidatorExistsForCountry('PR')).toBeTruthy();
+    expect(postcodeValidatorExistsForCountry('AU')).toBeTruthy();
+    expect(postcodeValidatorExistsForCountry('DE')).toBeTruthy();
+  });
 
-    test('should return false for invalid country code', () => {
-        expect.assertions(3);
-        expect(postcodeValidatorExistsForCountry('PO' as CountryCodeStrings)).toBeFalsy();
-        expect(postcodeValidatorExistsForCountry('SUN' as CountryCodeStrings)).toBeFalsy();
-        expect(postcodeValidatorExistsForCountry('STAR' as CountryCodeStrings)).toBeFalsy();
-    });
+  test('should return false for invalid country code', () => {
+    expect.assertions(3);
+    expect(postcodeValidatorExistsForCountry('PO' as CountryCodeStrings)).toBeFalsy();
+    expect(postcodeValidatorExistsForCountry('SUN' as CountryCodeStrings)).toBeFalsy();
+    expect(postcodeValidatorExistsForCountry('STAR' as CountryCodeStrings)).toBeFalsy();
+  });
 });

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,4 +1,3 @@
-import { CountryCodeStrings } from '../src/postcode-types';
 import { postcodeValidator, postcodeValidatorExistsForCountry } from '../src/main';
 
 describe('postcodeValidator', () => {
@@ -19,7 +18,7 @@ describe('postcodeValidator', () => {
 
     expect.assertions(validPostcodes.length);
     validPostcodes.forEach(({ postcode, country }) => {
-      expect(postcodeValidator(postcode, country as CountryCodeStrings)).toBeTruthy();
+      expect(postcodeValidator(postcode, country)).toBeTruthy();
     });
   });
 
@@ -36,13 +35,13 @@ describe('postcodeValidator', () => {
 
     expect.assertions(invalidPostcodes.length);
     invalidPostcodes.forEach(({ postcode, country }) => {
-      expect(postcodeValidator(postcode, country as CountryCodeStrings)).toBeFalsy();
+      expect(postcodeValidator(postcode, country)).toBeFalsy();
     });
   });
 
   test('should throw error for invalid country codes', () => {
     expect.assertions(1);
-    expect(() => postcodeValidator('SW1A 0AA', 'MOON' as CountryCodeStrings)).toThrow('Invalid country code: MOON');
+    expect(() => postcodeValidator('SW1A 0AA', 'MOON')).toThrow('Invalid country code: MOON');
   });
 });
 
@@ -56,8 +55,8 @@ describe('postcodeValidatorExistsForCountry', () => {
 
   test('should return false for invalid country code', () => {
     expect.assertions(3);
-    expect(postcodeValidatorExistsForCountry('PO' as CountryCodeStrings)).toBeFalsy();
-    expect(postcodeValidatorExistsForCountry('SUN' as CountryCodeStrings)).toBeFalsy();
-    expect(postcodeValidatorExistsForCountry('STAR' as CountryCodeStrings)).toBeFalsy();
+    expect(postcodeValidatorExistsForCountry('PO')).toBeFalsy();
+    expect(postcodeValidatorExistsForCountry('SUN')).toBeFalsy();
+    expect(postcodeValidatorExistsForCountry('STAR')).toBeFalsy();
   });
 });


### PR DESCRIPTION
#### What is this PR for?
Sometimes you want to validate a postal code from a country code in a string variable.  Converting a string to a list of `CountryCodeStrings` is kind of a pain and all the validation mechanics is already in place in the code.

I simply removed `CountryCodeStrings` and replaced its references by `string`.

#### Who should review this PR?
@melwynfurtado 

#### Questions:
- [ ] All unit tests executed successfully in CI environment
- [ ] Related tests executed successfully in CI environment
- [ ] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [ ] PR ready for merging
