### PR TITLE
Serbian postal code should allow 5 or 6 digits

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -126,7 +126,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.AS, /^96799$/],
   [CountryCode.CC, /^6799$/],
   [CountryCode.CK, /^\d{4}$/],
-  [CountryCode.RS, /^\d{6}$/],
+  [CountryCode.RS, /^\d{5,6}$/],
   [CountryCode.ME, /^8\d{4}$/],
   [CountryCode.CS, /^\d{5}$/],
   [CountryCode.YU, /^\d{5}$/],


### PR DESCRIPTION
#### What is this PR for?
The Serbian postal code validator should allow both 5 and 6 digits. 

A pretty thorough explanation of the current use of postcodes and PAK codes can be found here: https://github.com/google/libaddressinput/issues/99

TL;DR: the proposed 6 digit PAK seems never to have been adopted, therefore the 5 digit postcode remains in common use. Whether to allow only 5, or both 5 and 6 digits is up for debate.

This PR would fix #39 

#### Who should review this PR?
@melwynfurtado 

#### Questions:
- [ ] All unit tests executed successfully in CI environment
- [ ] Related tests executed successfully in CI environment
- [ ] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [ ] PR ready for merging
