### PR TITLE
Improve Spanish postal code regex

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -23,7 +23,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.IT, /^\d{5}$/],
   [CountryCode.CH, /^\d{4}$/],
   [CountryCode.AT, /^(?!0)\d{4}$/],
-  [CountryCode.ES, /^\d{5}$/],
+  [CountryCode.ES, /^(?:0[1-9]|[1-4]\d|5[0-2])\d{3}$/],
   [CountryCode.NL, /^\d{4}[ ]?[A-Z]{2}$/],
   [CountryCode.BE, /^\d{4}$/],
   [CountryCode.DK, /^\d{4}$/],

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -16,7 +16,8 @@ describe('postcodeValidator', () => {
       { postcode: 'D02 TN83', country: 'IE' },
       { postcode: 'FI-00121', country: 'FI' },
       { postcode: '9103401', country: 'IL' },
-      { postcode: '60198', country: 'IL' }
+      { postcode: '60198', country: 'IL' },
+      { postcode: '41008', country: 'ES' }
     ];
 
     expect.assertions(validPostcodes.length);
@@ -35,7 +36,9 @@ describe('postcodeValidator', () => {
       { postcode: 'M5K3D8', country: 'CA' },
       { postcode: '100-0005-9088', country: 'JP' },
       { postcode: '0234', country: 'AT' },
-      { postcode: 'DTN83', country: 'IE' }
+      { postcode: 'DTN83', country: 'IE' },
+      { postcode: '53000', country: 'ES' },
+      { postcode: '00999', country: 'ES' }
     ];
 
     expect.assertions(invalidPostcodes.length);


### PR DESCRIPTION
#### What is this PR for?
I'm improving the regex of the Spanish postal code, as before was checking only that it must be 5 digits.
The current Spanish postal code must begin from 01 to 52, and the 3 digits of the end could be from 000 to 999. 

More info: https://en.wikipedia.org/wiki/List_of_postal_codes_in_Spain

#### Who should review this PR?
@melwynfurtado

#### Questions:
- [ ] All unit tests executed successfully in CI environment
- [ ] Related tests executed successfully in CI environment
- [x] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [x] PR ready for merging
