### PR TITLE
fix: allow 6-digit Taiwanese postcodes

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -34,7 +34,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.AX, /^22\d{3}$/],
   [CountryCode.KR, /^\d{5}$/],
   [CountryCode.CN, /^\d{6}$/],
-  [CountryCode.TW, /^\d{3}(\d{2})?$/],
+  [CountryCode.TW, /^\d{3}(\d{2,3})?$/],
   [CountryCode.SG, /^\d{6}$/],
   [CountryCode.DZ, /^\d{5}$/],
   [CountryCode.AD, /^AD\d{3}$/],

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -20,6 +20,8 @@ describe('postcodeValidator', () => {
       { postcode: '41008', country: 'ES' },
       { postcode: 'KY3-0001', country: 'KY' },
       { postcode: '01000', country: 'PE' },
+      { postcode: '12345', country: 'TW' },
+      { postcode: '123456', country: 'TW' },
     ];
 
     expect.assertions(validPostcodes.length);


### PR DESCRIPTION
#### What is this PR for?
Taiwanese postcodes can be 6-characters long (3 mandatory digits + 2 or 3 optional digits). 

This PR updates that and adds tests for  both kinds of TW postcode too.

#### Who should review this PR?
@melwynfurtado 

#### Questions:
- [ ] All unit tests executed successfully in CI environment
- [ ] Related tests executed successfully in CI environment
- [ ] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [ ] PR ready for merging
