### PR TITLE
Fix Mongolia postcode to be 5 digits.

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -150,7 +150,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.LS, /^\d{3}$/],
   [CountryCode.MG, /^\d{3}$/],
   [CountryCode.MH, /^969[67]\d([ \-]\d{4})?$/],
-  [CountryCode.MN, /^\d{6}$/],
+  [CountryCode.MN, /^\d{5}$/],
   [CountryCode.MP, /^9695[012]([ \-]\d{4})?$/],
   [CountryCode.MQ, /^9[78]2\d{2}$/],
   [CountryCode.NC, /^988\d{2}$/],


### PR DESCRIPTION
#### What is this PR for?
Mongolia postcode is made of 5 digits, not 6. I couldn't find definitive guide for this, but all addresses on google maps point to 5 digits.

#### Who should review this PR?
<State the Git users you would like to review the PR>

#### Questions:
- [x] All unit tests executed successfully in CI environment
- [x] Related tests executed successfully in CI environment
- [x] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [x] PR ready for merging
