### PR TITLE
feat: add cp for Colombia, and improve regex from peru

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -171,6 +171,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.WF, /^986\d{2}$/],
   [CountryCode.XK, /^\d{5}$/],
   [CountryCode.YT, /^976\d{2}$/],
-  [CountryCode.PE, /^\d{5}$/],
+  [CountryCode.PE, /^[0-2][0-9]\d{3}$/],
   [CountryCode.INTL, /^(?:[A-Z0-9]+([- ]?[A-Z0-9]+)*)?$/i],
+  [CountryCode.CO, /^(0[58]|1[135789]|2[0357]|4[147]|5[024]|6[368]|7[036]|8[1568]|9[4579])\d{4}$/],
 ]);

--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -171,7 +171,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.WF, /^986\d{2}$/],
   [CountryCode.XK, /^\d{5}$/],
   [CountryCode.YT, /^976\d{2}$/],
-  [CountryCode.PE, /^[0-2][0-9]\d{3}$/],
+  [CountryCode.PE, /^[0-2]\d{4}$/],
   [CountryCode.INTL, /^(?:[A-Z0-9]+([- ]?[A-Z0-9]+)*)?$/i],
   [CountryCode.CO, /^(0[58]|1[135789]|2[0357]|4[147]|5[024]|6[368]|7[036]|8[1568]|9[4579])\d{4}$/],
 ]);

--- a/src/postcode-types.ts
+++ b/src/postcode-types.ts
@@ -164,4 +164,5 @@ export enum CountryCode {
   YT = 'YT',
   PE = 'PE',
   INTL = 'INTL',
+  CO = 'CO'
 }


### PR DESCRIPTION
#### What is this PR for?
This PR enhances the accuracy of postcode validation for Colombia and Peru. The following modifications have been made:

    Colombia: A new regular expression has been added to validate Colombian postcodes, ensuring they adhere to the format specified by the Colombian postal service.
    Peru: The existing regular expression for Peruvian postcodes has been refined, allowing for more stringent validation and capturing a wider variety of valid formats.

#### Who should review this PR?
@melwynfurtado 

#### Questions:
- [x ] All unit tests executed successfully in CI environment
- [ x] Related tests executed successfully in CI environment
- [x] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [ x] PR ready for merging
