### PR TITLE
AR: mandatory province prefix

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -39,7 +39,7 @@ export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [CountryCode.SG, /^\d{6}$/],
   [CountryCode.DZ, /^\d{5}$/],
   [CountryCode.AD, /^AD\d{3}$/],
-  [CountryCode.AR, /^([A-HJ-NP-Z])?\d{4}([A-Z]{3})?$/],
+  [CountryCode.AR, /^[A-HJ-NP-Z]\d{4}([A-Z]{3})?$/],
   [CountryCode.AM, /^(37)?\d{4}$/],
   [CountryCode.AZ, /^\d{4}$/],
   [CountryCode.BH, /^((1[0-2]|[2-9])\d{2})?$/],


### PR DESCRIPTION
Ensure the presence of the (mandatory) disambiguation province prefix

#### What is this PR for?
Argentina postal codes were historically assigned on a province basis without great care for duplication on national level.
Decades ago the postal code got a formal province-based prefixing letter assigned.
When using webforms opened to the whole country, this prefix is important because out of 20k localities, more than 100 are using the same postal-code across distinct provinces (list provided below ¹)


#### Who should review this PR?


#### Questions:
- [x] All unit tests executed successfully in CI environment
- [x] Related tests executed successfully in CI environment
- [x] Documentation updated accordingly [e.g. Readme.md, Contributing.md]
- [x] PR ready for merging




#### Additional information
¹ Argentina ambiguous postal codes

```
+------------+------+-----------+
| occurences | cp   | provinces |
+------------+------+-----------+
|        154 | 4178 | G,T       |
|        114 | 4187 | G,T       |
|        105 | 4176 | G,T       |
|         75 | 3714 | G,H       |
|         72 | 5255 | G,X       |
|         65 | 9420 | V,Z       |
|         63 | 3636 | A,P       |
|         60 | 4230 | G,K       |
|         59 | 4415 | A,G       |
|         59 | 5260 | G,K       |
|         55 | 6279 | D,M,X     |
|         52 | 5871 | D,X       |
|         51 | 5249 | G,X       |
|         50 | 4184 | G,T       |
|         48 | 4434 | A,T       |
|         47 | 4651 | A,Y       |
|         46 | 4452 | A,G       |
|         43 | 4128 | A,T       |
|         38 | 1647 | B,E       |
|         36 | 3712 | G,H       |
|         36 | 4633 | A,Y       |
|         35 | 5209 | G,X       |
|         31 | 4141 | A,K,T     |
|         31 | 4644 | A,Y       |
|         30 | 5831 | D,X       |
|         29 | 2805 | B,E       |
|         28 | 8138 | L,R       |
|         27 | 4126 | A,T       |
|         27 | 5621 | L,M       |
|         26 | 4411 | A,Y       |
|         26 | 5435 | J,M       |
|         25 | 4413 | A,Y       |
|         25 | 5738 | D,X       |
|         22 | 3620 | H,P       |
|         22 | 4234 | G,K       |
|         21 | 3306 | N,W       |
|         19 | 3300 | N,W       |
|         19 | 4186 | G,T       |
|         19 | 5873 | D,X       |
|         18 | 4231 | G,K       |
|         17 | 3061 | G,S       |
|         17 | 3185 | E,W       |
|         17 | 3474 | G,W       |
|         17 | 4195 | A,G,T     |
|         17 | 4561 | A,Y       |
|         17 | 5263 | F,K       |
|         17 | 8401 | Q,R       |
|         16 | 1649 | B,E       |
|         16 | 3734 | G,H       |
|         16 | 5636 | D,M       |
|         14 | 3516 | H,S       |
|         14 | 3526 | H,P       |
|         14 | 8134 | B,R       |
|         14 | 8305 | Q,R       |
|         14 | 8360 | Q,R       |
|         13 | 8415 | R,U       |
|         12 | 3358 | N,W       |
|         12 | 3541 | H,S       |
|         12 | 3621 | H,P       |
|         12 | 4237 | G,K       |
|         12 | 6214 | D,L       |
|         12 | 8307 | L,R       |
|         12 | 8403 | Q,R       |
|         11 | 3224 | E,W       |
|         10 | 5637 | D,M       |
|         10 | 6341 | B,L       |
|         10 | 8313 | Q,R       |
|         10 | 8400 | Q,R       |
|          9 | 5272 | F,X       |
|          9 | 9210 | R,U       |
|          8 | 2341 | G,S,X     |
|          8 | 2349 | S,X       |
|          8 | 2415 | S,X       |
|          8 | 8336 | L,R       |
|          8 | 8430 | R,U       |
|          7 | 2701 | B,S       |
|          7 | 3731 | G,H       |
|          7 | 5421 | D,J       |
|          7 | 8504 | B,R       |
|          6 | 2804 | B,E       |
|          6 | 3351 | N,W       |
|          6 | 4542 | A,Y       |
|          6 | 8532 | R,U       |
|          5 | 2344 | G,S       |
|          5 | 3194 | E,W       |
|          5 | 3511 | H,P       |
|          5 | 5266 | G,K       |
|          5 | 6621 | B,L       |
|          5 | 8301 | Q,R       |
|          5 | 8505 | B,R       |
|          4 | 2401 | S,X       |
|          4 | 2720 | B,S       |
|          4 | 6239 | B,L       |
|          3 | 2000 | E,S       |
|          3 | 2400 | S,X       |
|          3 | 2723 | B,S       |
|          3 | 5717 | D,F       |
|          3 | 6348 | B,L       |
|          2 | 2340 | G,S       |
|          2 | 6101 | B,X       |
+------------+------+-----------+
```


For example, **2000** is used by Rosario and... Villa Angelica (Entre Ríos)
- https://arg.postcodebase.com/node/18083
- https://arg.postcodebase.com/node/8533

Or **4195** used in [Tucumán](https://arg.postcodebase.com/node/21051) but also in [Salta](https://arg.postcodebase.com/node/14645) and [Santiago del Estero](https://arg.postcodebase.com/node/19971)
