### PR TITLE
fix(GB): reject postcodes with non-letter symbols in the inward code

### DIFF
--- a/src/postcode-regexes.ts
+++ b/src/postcode-regexes.ts
@@ -4,11 +4,11 @@ import { CountryCode } from './postcode-types';
 export const POSTCODE_REGEXES: Map<string, RegExp> = new Map([
   [
     CountryCode.UK,
-    /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-z][A-z]){1}$/i,
+    /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-Z][A-Z]){1}$/i,
   ],
   [
     CountryCode.GB,
-    /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-z][A-z]){1}$/i,
+    /^([A-Z]){1}([0-9][0-9]|[0-9]|[A-Z][0-9][A-Z]|[A-Z][0-9][0-9]|[A-Z][0-9]|[0-9][A-Z]){1}([ ])?([0-9][A-Z][A-Z]){1}$/i,
   ],
   [CountryCode.JE, /^JE\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}$/],
   [CountryCode.GG, /^GY\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}$/],

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -38,6 +38,8 @@ describe('postcodeValidator', () => {
       { postcode: '123456', country: 'US' },
       { postcode: '12345 6789', country: 'US' },
       { postcode: '1234567', country: 'GB' },
+      { postcode: 'SW1A 0A[', country: 'GB' },
+      { postcode: 'W6 8D]', country: 'GB' },
       { postcode: 'M5P@2N7', country: 'CA' },
       { postcode: 'M5K3D8', country: 'CA' },
       { postcode: '100-0005-9088', country: 'JP' },


### PR DESCRIPTION
## Summary

The postcode pattern for `GB` (and its deprecated `UK` alias) uses `[A-z]` for the two trailing letters of the inward code. `[A-z]` is **not** "any letter": the range `A`–`z` (ASCII 65–122) also contains the six characters `` [ \ ] ^ _ ` `` that sit between `Z` (90) and `a` (97). So strings with those symbols in the last two positions are accepted as valid UK postcodes.

## Reproduction (v3.x)

```js
const { postcodeValidator } = require('postcode-validator');

postcodeValidator('SW1A 0A[', 'GB'); // true — should be false
postcodeValidator('W6 8D]',  'GB');  // true — should be false
postcodeValidator('B33 8T^', 'GB');  // true — should be false
```

## Fix

Replace `[A-z]` with `[A-Z]` in the `GB`/`UK` patterns. The regex already carries the `i` flag (and uses `[A-Z]` for every other letter class), so lowercase input keeps working — only the stray punctuation is now rejected.

```diff
-    ([ ])?([0-9][A-z][A-z]){1}$/i
+    ([ ])?([0-9][A-Z][A-Z]){1}$/i
```

## Tests

Added two `GB` cases to the invalid fixtures (`SW1A 0A[`, `W6 8D]`). They fail on the current code and pass with this change; all existing valid and invalid fixtures are unaffected.
